### PR TITLE
The DotProduct type must be signed

### DIFF
--- a/minroots.h
+++ b/minroots.h
@@ -19,7 +19,7 @@ namespace minroots {
 
 namespace minroots {
   typedef unsigned MinNbr;
-  typedef char DotProduct;
+  typedef signed char DotProduct;
   class MinTable;
 };
 


### PR DESCRIPTION
The type `char` may be signed or unsigned depending on the system. But the `DotProduct` type is used for arithmetic where negative values can occur.