### PR TITLE
streamline things for a Homebrew tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.bak
+*.swp
+libcoxeter3.*
+directories.h
+coxeter

--- a/directories.h
+++ b/directories.h
@@ -25,9 +25,9 @@
 */
 
 namespace directories {
-  const char* const COXMATRIX_DIR = "/usr/local/coxeter/coxeter_matrices";
-  const char* const HEADER_DIR = "/usr/local/coxeter/headers";
-  const char* const MESSAGE_DIR = "/usr/local/coxeter/messages";
+  const char* const COXMATRIX_DIR = "@SAGE_LOCAL@/coxeter/coxeter_matrices";
+  const char* const HEADER_DIR = "@SAGE_LOCAL@/coxeter/headers";
+  const char* const MESSAGE_DIR = "@SAGE_LOCAL@/coxeter/messages";
 };
 
 #endif

--- a/directories.h.in
+++ b/directories.h.in
@@ -25,9 +25,9 @@
 */
 
 namespace directories {
-  const char* const COXMATRIX_DIR = "@SAGE_LOCAL@/coxeter/coxeter_matrices";
-  const char* const HEADER_DIR = "@SAGE_LOCAL@/coxeter/headers";
-  const char* const MESSAGE_DIR = "@SAGE_LOCAL@/coxeter/messages";
+  const char* const COXMATRIX_DIR = "@PREFIX@/share/coxeter/coxeter_matrices";
+  const char* const HEADER_DIR = "@PREFIX@/share/coxeter/headers";
+  const char* const MESSAGE_DIR = "@PREFIX@/share/coxeter/messages";
 };
 
 #endif

--- a/makefile
+++ b/makefile
@@ -12,6 +12,7 @@ oflags = -c $(includedirs) -O -Wall
 gflags = -c $(includedirs) -g
 
 cflags = $(gflags) # the default setting
+cflags = -c $(includedirs) -O2 -fPIC -g
 
 ifdef optimize
 	NDEBUG = true
@@ -22,18 +23,78 @@ ifdef profile
 	cflags = $(pflags)
 endif
 
-cc = g++
+EXENAME = coxeter
+LIBNAME = coxeter3
+ifeq ($(UNAME),Darwin)
+	EXEEXT = 
+	LIBPREFIX = lib
+	LIBEXT = .dylib
+	LIBDIR = lib
+	LINKFLAGS = -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,3.0,-current_version,3.0,-install_name,$(SAGE_LOCAL)/lib/$(LIBPREFIX)$(LIBNAME)$(LIBEXT)
+	LINKLIBS = 
+else
+ifeq ($(UNAME),CYGWIN)
+	EXEEXT = .exe
+	LIBPREFIX = cyg
+	LIBEXT = .dll
+	LIBDIR = bin
+	IMPLIB = lib$(LIBNAME).dll.a
+	LINKFLAGS = -shared -Wl,--out-implib=$(IMPLIB) -Wl,--export-all-symbols
+	LINKLIBS = -lc
+else
+	EXEEXT = 
+	LIBPREFIX = lib
+	LIBEXT = .so
+	LIBDIR = lib
+	LINKFLAGS = -shared -Wl,-soname,libcoxeter3.so
+	LINKLIBS = -lc
+endif
+endif
+LIBRARY = $(LIBPREFIX)$(LIBNAME)$(LIBEXT)
 
-all: coxeter #clean
+all: coxeter executable
 
 coxeter: $(objects)
-	$(cc) -o coxeter $(objects)
+	$(CXX) $(LINKFLAGS) -o $(LIBRARY) $(objects) $(LINKLIBS)
+
+executable: $(objects)
+	$(CXX) -o $(EXENAME)$(EXEEXT) $(objects)
+
+BINDIR=$$SAGE_LOCAL/bin/
+DATADIR=$$SAGE_LOCAL/coxeter/
+INCLUDEDIR=$$SAGE_LOCAL/include/coxeter/
+LIBRARYDIR=$$SAGE_LOCAL/$(LIBDIR)
+
+install: coxeter executable
+	mkdir -p "$(DESTDIR)$(BINDIR)"
+	mkdir -p "$(DESTDIR)$(LIBRARYDIR)"
+	cp $(EXENAME)$(EXEEXT) "$(DESTDIR)$(BINDIR)"
+	cp $(LIBRARY) "$(DESTDIR)$(LIBRARYDIR)"
+	if [ $(UNAME) = "CYGWIN" ]; then                 \
+	    mkdir -p "$(DESTDIR)$$SAGE_LOCAL/lib/";      \
+	    cp $(IMPLIB) "$(DESTDIR)$$SAGE_LOCAL/lib/";  \
+	fi
+
+	mkdir -p "$(DESTDIR)$(DATADIR)"
+	cp -r coxeter_matrices headers messages "$(DESTDIR)$(DATADIR)"
+	mkdir -p "$(DESTDIR)$(INCLUDEDIR)"
+	cp -r *.h *.hpp "$(DESTDIR)$(INCLUDEDIR)"
+
+check: coxeter executable
+	$(EXENAME)$(EXEEXT) < test.input > test.output
+
+	if ! diff test.output.expected test.output > /dev/null; then \
+	   echo >&2 "Error testing coxeter on test.input:"; \
+	   diff test.output.expected test.output; \
+	   exit 1; \
+	fi
+	rm -f test.output
 
 clean:
 	rm -f $(objects)
 
 %.o:%.cpp
-	$(cc) $(cflags) $*.cpp
+	$(CXX) $(cflags) $*.cpp
 
 # dependencies --- these were generated automatically by make depend on my
 # system; they are explicitly copied for portability. Only local dependencies
@@ -43,7 +104,7 @@ clean:
 # contents of tmp in lieu of the dependencies listed here.
 
 %.d:%.cpp
-	@$(cc) -MM $*.cpp
+	@$(CXX) -MM $*.cpp
 depend: $(dependencies)
 
 affine.o: affine.cpp affine.h globals.h coxgroup.h coxtypes.h io.h list.h \

--- a/makefile
+++ b/makefile
@@ -54,6 +54,9 @@ LIBRARY = $(LIBPREFIX)$(LIBNAME)$(LIBEXT)
 
 all: coxeter executable
 
+direcrories.h: directories.h.in
+        $(SED) "s|@PREFIX@|$PREFIX|g" directories.h.in > directories.h
+
 coxeter: $(objects)
 	$(CXX) $(LINKFLAGS) -o $(LIBRARY) $(objects) $(LINKLIBS)
 

--- a/makefile
+++ b/makefile
@@ -25,15 +25,16 @@ endif
 
 EXENAME = coxeter
 LIBNAME = coxeter3
-ifeq ($(UNAME),Darwin)
+OS = $(shell uname)
+ifeq ($(OS),Darwin)
 	EXEEXT = 
 	LIBPREFIX = lib
 	LIBEXT = .dylib
 	LIBDIR = lib
-	LINKFLAGS = -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,3.0,-current_version,3.0,-install_name,$(SAGE_LOCAL)/lib/$(LIBPREFIX)$(LIBNAME)$(LIBEXT)
+	LINKFLAGS = -dynamiclib -Wl,-headerpad_max_install_names,-undefined,dynamic_lookup,-compatibility_version,3.0,-current_version,3.0,-install_name,$(PREFIX)/lib/$(LIBPREFIX)$(LIBNAME)$(LIBEXT)
 	LINKLIBS = 
 else
-ifeq ($(UNAME),CYGWIN)
+ifeq ($(OS),CYGWIN)
 	EXEEXT = .exe
 	LIBPREFIX = cyg
 	LIBEXT = .dll
@@ -54,8 +55,8 @@ LIBRARY = $(LIBPREFIX)$(LIBNAME)$(LIBEXT)
 
 all: coxeter executable
 
-direcrories.h: directories.h.in
-        $(SED) "s|@PREFIX@|$PREFIX|g" directories.h.in > directories.h
+directories.h: directories.h.in
+	sed "s|@PREFIX@|$(PREFIX)|g" directories.h.in > directories.h
 
 coxeter: $(objects)
 	$(CXX) $(LINKFLAGS) -o $(LIBRARY) $(objects) $(LINKLIBS)
@@ -63,19 +64,19 @@ coxeter: $(objects)
 executable: $(objects)
 	$(CXX) -o $(EXENAME)$(EXEEXT) $(objects)
 
-BINDIR=$$SAGE_LOCAL/bin/
-DATADIR=$$SAGE_LOCAL/coxeter/
-INCLUDEDIR=$$SAGE_LOCAL/include/coxeter/
-LIBRARYDIR=$$SAGE_LOCAL/$(LIBDIR)
+BINDIR=$$PREFIX/bin/
+DATADIR=$$PREFIX/coxeter/
+INCLUDEDIR=$$PREFIX/include/coxeter/
+LIBRARYDIR=$$PREFIX/$(LIBDIR)
 
 install: coxeter executable
 	mkdir -p "$(DESTDIR)$(BINDIR)"
 	mkdir -p "$(DESTDIR)$(LIBRARYDIR)"
 	cp $(EXENAME)$(EXEEXT) "$(DESTDIR)$(BINDIR)"
 	cp $(LIBRARY) "$(DESTDIR)$(LIBRARYDIR)"
-	if [ $(UNAME) = "CYGWIN" ]; then                 \
-	    mkdir -p "$(DESTDIR)$$SAGE_LOCAL/lib/";      \
-	    cp $(IMPLIB) "$(DESTDIR)$$SAGE_LOCAL/lib/";  \
+	if [ $(OS) = "CYGWIN" ]; then                 \
+	    mkdir -p "$(DESTDIR)$$PREFIX/lib/";      \
+	    cp $(IMPLIB) "$(DESTDIR)$$PREFIX/lib/";  \
 	fi
 
 	mkdir -p "$(DESTDIR)$(DATADIR)"
@@ -84,7 +85,7 @@ install: coxeter executable
 	cp -r *.h *.hpp "$(DESTDIR)$(INCLUDEDIR)"
 
 check: coxeter executable
-	$(EXENAME)$(EXEEXT) < test.input > test.output
+	./$(EXENAME)$(EXEEXT) < test.input > test.output
 
 	if ! diff test.output.expected test.output > /dev/null; then \
 	   echo >&2 "Error testing coxeter on test.input:"; \

--- a/sage.cpp
+++ b/sage.cpp
@@ -1,0 +1,56 @@
+/*
+  Coxeter version 3.0 Copyright (C) 2009 Mike Hansen
+  See file main.cpp for full copyright notice
+*/
+
+#include "sage.h"
+
+namespace sage {
+
+  void interval(List<CoxWord>& list, CoxGroup& W, const CoxWord& g, const CoxWord& h)
+
+  /*
+     Returns a list of the elements in the Bruhat interval between g and h.
+     Note that this assumes that g and h are in order.
+   */
+  {
+    if (not W.inOrder(g,h)) {
+      return;
+    }
+
+    W.extendContext(h);
+
+    CoxNbr x = W.contextNumber(g);
+    CoxNbr y = W.contextNumber(h);
+
+    BitMap b(W.contextSize());
+    W.extractClosure(b,y);
+
+    BitMap::ReverseIterator b_rend = b.rend();
+    List<CoxNbr> res(0);
+
+    for (BitMap::ReverseIterator i = b.rbegin(); i != b_rend; ++i)
+      if (not W.inOrder(x,*i)) {
+        BitMap bi(W.contextSize());
+        W.extractClosure(bi,*i);
+        CoxNbr z = *i; // andnot will invalidate iterator
+        b.andnot(bi);
+        b.setBit(z);   // otherwise the decrement will not be correct
+      } else
+        res.append(*i);
+
+    schubert::NFCompare nfc(W.schubert(),W.ordering());
+    Permutation a(res.size());
+    sortI(res,nfc,a);
+
+    list.setSize(0);
+    for (size_t j = 0; j < res.size(); ++j) {
+      CoxWord w(0);
+      W.schubert().append(w, res[a[j]]);
+      list.append(w);
+    }
+
+    return;
+  }
+
+}

--- a/sage.h
+++ b/sage.h
@@ -1,0 +1,23 @@
+/*
+  Coxeter version 3.0 Copyright (C) 2009 Mike Hansen
+  See file main.cpp for full copyright notice
+*/
+
+#ifndef SAGE_H /* guard against multiple inclusions */
+#define SAGE_H
+
+#include "globals.h"
+#include "coxgroup.h"
+#include "coxtypes.h"
+#include "schubert.h"
+#include "list.h"
+
+namespace sage {
+  using namespace coxeter;
+  using namespace coxtypes;
+  using namespace list;
+
+  void interval(List<CoxWord>& result, CoxGroup& W, const CoxWord& g, const CoxWord& h);
+}
+
+#endif

--- a/test.input
+++ b/test.input
@@ -1,0 +1,9 @@
+type
+A
+3
+compute
+1 3 2 1 2 3 1 2 1
+ihbetti
+213
+q
+q

--- a/test.output.expected
+++ b/test.output.expected
@@ -1,0 +1,13 @@
+This is Coxeter version 3.1.
+Enter help if you need assistance, carriage return to start the program.
+
+coxeter : 
+type : 
+rank : coxeter : enter your element (finish with a carriage return) :
+213
+coxeter : enter your element (finish with a carriage return) :
+h[0] = 1  h[1] = 3  h[2] = 3  h[3] = 1  
+
+size : 8
+
+coxeter : coxeter : 


### PR DESCRIPTION
I wanted to make a Homebrew tap for coxeter, but it's too messy as it is now, so I applied Sage's patched to the trunk, and also did few simplifications and de-Saging (created a makefile rule to fill in a template, `s/SAGE_LOCAL/PREFIX`.

Now to install to `/foo/bar` one can just runs `make install PREFIX=/foo/bar`

On Homebrew it can be installed by doing `brew install dimpase/tap/coxeter3`.
(and the formula is here: https://github.com/dimpase/homebrew-tap/blob/main/Formula/c/coxeter3.rb)

How about merging all this, and then we can update the Sage's spkg install too.


